### PR TITLE
upkeep: improve error handling

### DIFF
--- a/R/generate_package_table.R
+++ b/R/generate_package_table.R
@@ -24,12 +24,12 @@ generate_package_table <- function(repo_paths) {
 
   dplyr::transmute(
     out,
-    Repo = format_repo(repo),
-    Lifecycle = format_lifecycle(lifecycle),
-    Status = format_status(repo, status),
-    Latest_SHA = format_latest_sha(repo, sha),
-    Maintainer = format_maintainer(maintainer)
-    )
+    Repo = format_repo_v(repo),
+    Lifecycle = format_lifecycle_v(lifecycle),
+    Status = format_status_v(repo, status),
+    Latest_SHA = format_latest_sha_v(repo, sha),
+    Maintainer = format_maintainer_v(maintainer)
+  )
 }
 
 format_repo <- function(repo) {
@@ -37,21 +37,41 @@ format_repo <- function(repo) {
   glue::glue("[{repo_base}](https://github.com/{repo})")
 }
 
+format_repo_v <- Vectorize(format_repo)
+
 format_lifecycle <- function(lifecycle_badge) {
+  if (is.na(lifecycle_badge)) {
+    return("No lifecycle badge found.")
+  }
+
   desc <- "![Lifecycle]"
   link <- "https://lifecycle.r-lib.org/articles/stages.html"
 
   glue::glue("[{desc}({lifecycle_badge})]({link})")
 }
 
+format_lifecycle_v <- Vectorize(format_lifecycle)
+
 format_status <- function(repo, r_cmd_check_status) {
+
+  if (is.na(r_cmd_check_status)) {
+    return("No R CMD check found.")
+  }
+
   desc <- "![R-CMD-check]"
   link <- glue::glue("https://github.com/{repo}/actions/workflows/R-CMD-check.yaml")
 
   glue::glue("[{desc}({r_cmd_check_status})]({link})")
 }
 
+format_status_v <- Vectorize(format_status)
+
 format_latest_sha <- function(repo, sha) {
+
+  if (is.na(sha)) {
+    return("`main` branch not found.")
+  }
+
   short_sha <- substr(sha, 1, 7)
 
   glue::glue(
@@ -59,19 +79,36 @@ format_latest_sha <- function(repo, sha) {
   )
 }
 
+format_latest_sha_v <- Vectorize(format_latest_sha)
+
 format_maintainer <- function(maintainer) {
+
+  if (is.na(maintainer)) {
+    return("No maintainer found.")
+  }
+
   glue::glue(
     "[@{maintainer}](https://github.com/{maintainer}/)"
   )
 }
 
+format_maintainer_v <- Vectorize(format_maintainer)
+
 table_lifecycle <- function(repo_path) {
   readme <- fetch_readme(repo_path)
+
+  if (is.null(readme)) {
+    return(NA_character_)
+  }
 
   pattern <- "https://img.shields.io/badge/lifecycle-.*.svg"
 
   lifecycle_badge <- readme[grepl(pattern, readme)]
   lifecycle_badge <- gsub(".*(https[^)]*\\.svg).*", "\\1", lifecycle_badge)
+
+  if (length(lifecycle_badge) == 0) {
+    return(NA_character_)
+  }
 
   return(lifecycle_badge)
 }
@@ -87,16 +124,27 @@ table_status <- function(repo_path) {
 table_latest_sha <- function(repo_path) {
   latest_sha <- fetch_main_sha(repo_path)
 
+  if (is.null(latest_sha)) {
+    return(NA_character_)
+  }
+
   return(latest_sha)
 }
 
 table_maintainer <- function(repo_path) {
   codeowners <- fetch_codeowners(repo_path)
+  if (is.null(codeowners)) {
+    return(NA_character_)
+  }
 
   maintainer <- codeowners[!grepl("^#", codeowners)]
   maintainer <- maintainer[grepl("^*", maintainer)]
   maintainer <- maintainer[grepl("^.*@.*$", maintainer)]
   maintainer <- gsub("^.*@(.*)$", "\\1", maintainer)
+
+  if (length(maintainer) == 0) {
+    return(NA_character_)
+  }
 
   return(maintainer)
 }


### PR DESCRIPTION
This PR slightly improves the error handling of `generate_package_table()`.
I'm still not totally happy with this set-up, but it's better than nothing.

I also had to vectorized the `format_*` functions to improve the error handling there. 

Note: There are no checks for existence of the R CMD check badges, since I am just using `glue` to create that link, and not fetching anything using `gh`. However, if it doesn't exist, the default behaviour seems fine as it just renders as a broken link, see reprex below.

Relates to https://github.com/RMI-PACTA/pacta.sit.rep/pull/6#issuecomment-2022588015
(No related issue)

``` r
library(pacta.sit.rep)
library(knitr)

# good urls
repos <- c("RMI-PACTA/r2dii.data", "RMI-PACTA/r2dii.match")

repos |> 
  generate_package_table() |> 
  kable()
```

| Repo                                                    | Lifecycle                                                                                                                  | Status                                                                                                                                                                               | Latest_SHA                                                         | Maintainer                              |
|:--------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------|:----------------------------------------|
| [r2dii.data](https://github.com/RMI-PACTA/r2dii.data)   | [![Lifecycle](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html) | [![R-CMD-check](https://github.com/RMI-PACTA/r2dii.data/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/RMI-PACTA/r2dii.data/actions/workflows/R-CMD-check.yaml)   | [`bff9bad`](https://github.com/RMI-PACTA/r2dii.data/commits/main)  | [@jdhoffa](https://github.com/jdhoffa/) |
| [r2dii.match](https://github.com/RMI-PACTA/r2dii.match) | [![Lifecycle](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html) | [![R-CMD-check](https://github.com/RMI-PACTA/r2dii.match/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/RMI-PACTA/r2dii.match/actions/workflows/R-CMD-check.yaml) | [`41b878a`](https://github.com/RMI-PACTA/r2dii.match/commits/main) | [@jdhoffa](https://github.com/jdhoffa/) |

``` r

# using an old repo that has almost nothing
repos <- c("RMI-PACTA/2dii-climateworks")

repos |> 
  generate_package_table() |> 
  kable()
```

| Repo                                                                | Lifecycle                 | Status                                                                                                                                                                                           | Latest_SHA               | Maintainer           |
|:--------------------------------------------------------------------|:--------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------|:---------------------|
| [2dii-climateworks](https://github.com/RMI-PACTA/2dii-climateworks) | No lifecycle badge found. | [![R-CMD-check](https://github.com/RMI-PACTA/2dii-climateworks/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/RMI-PACTA/2dii-climateworks/actions/workflows/R-CMD-check.yaml) | `main` branch not found. | No maintainer found. |

<sup>Created on 2024-03-27 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>