### PR TITLE
upkeep: gains simple error handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pacta.sit.rep
 Title: What the Package Does (One Line, Title Case)
-Version: 0.0.0.9004
+Version: 0.0.0.9005
 Authors@R: 
     person("Jackson", "Hoffart", , "jackson.hoffart@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-8600-5042"))

--- a/R/generate_package_table.R
+++ b/R/generate_package_table.R
@@ -116,6 +116,10 @@ table_status <- function(repo_path) {
 
   r_cmd_check_status <- readme[grepl("R.yml|R-CMD-check.yaml", readme)]
 
+  if (is.null(r_cmd_check_status) | length(r_cmd_check_status) == 0) {
+    return(NA_character_)
+  }
+
   return(r_cmd_check_status)
 }
 


### PR DESCRIPTION
Testing locally revealed that, in the case the repo contained no R CMD Check badge, this function would fail. 

This simple handling ensures that the function still passes, with an informative output.