### PR TITLE
ci/cd: Update nightly-readme-build.yml

### DIFF
--- a/.github/workflows/nightly-readme-build.yml
+++ b/.github/workflows/nightly-readme-build.yml
@@ -29,10 +29,16 @@ jobs:
         run: |
           Rscript -e 'pak::local_install(".")'
 
-      - name: Render README.Rmd file and Commit Results
+      - name: Render README.Rmd file
         run: |
           Rscript -e 'rmarkdown::render("README.Rmd")'
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git commit README.md -m 'Re-build Rmarkdown files' || echo "No changes to commit"
-          git push origin || echo "No changes to commit"
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: GH - Render README
+          title: GH - Render README
+          body: GH action to re-knit the README.Rmd 
+          base: main
+          labels: ci/cd
+          branch: nightly_readme_build
+          delete-branch: true


### PR DESCRIPTION
Use GH action to build `README.Rmd` and commit it to a new PR (as opposed to pushing directly to `main`). 

Sorry @cjyetman for the back-to-back GH action PRs here. It's difficult to test these without merging them in. 

Maybe closes #28 