### PR TITLE
Add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 # pacta.sit.rep <img src="assets/images/logo.png" align="right" width="120" />
 
+[![Project Status: Unsupported](https://www.repostatus.org/badges/latest/unsupported.svg)](https://www.repostatus.org/#unsupported)
+
+**This project is archived for future reference, but no new work is expected in this repository.**
+
 <!-- badges: start -->
 
 [![Lifecycle:experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)


### PR DESCRIPTION
This PR marks the repository as archived in the README by adding the unsupported badge and archive notice under the main header.